### PR TITLE
Fix sbt version for g8

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.0
+sbt.version=0.13.16


### PR DESCRIPTION
Sorry for continuous PR, g8 does not support sbt 1.0.0 yet https://github.com/foundweekends/giter8/issues/318

* sbt: 0.13.16 for g8
* (sbt: 1.0.0 in template as it is)