### PR TITLE
Update sbt version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.3

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.0
+sbt.version=1.0.3


### PR DESCRIPTION
My system sbt is `1.0.3`, but running `sbt new scala/hello-world.g8` sets the build.properties sbt version at `1.0.0` which is [buggy](https://github.com/sbt/sbt/issues/3453). If there's a reason to leave this in the `0.13.x` let me know.