### PR TITLE
Remove cats from initial libraryDependencies.

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -25,25 +25,25 @@ version := "1.0"
 // Want to use a published library in your project?
 // You can define other libraries as dependencies in your build like this:
 
-// libraryDependencies += "org.typelevel" %% "cats-core" % "2.0.0"
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
 
 // Here, `libraryDependencies` is a set of dependencies, and by using `+=`,
-// we're adding the cats dependency to the set of dependencies that sbt will go
-// and fetch when it starts up.
-// Now, in any Scala file, you can import classes, objects, etc., from cats with
-// a regular import.
+// we're adding the scala-parser-combinators dependency to the set of dependencies
+// that sbt will go and fetch when it starts up.
+// Now, in any Scala file, you can import classes, objects, etc., from
+// scala-parser-combinators with a regular import.
 
 // TIP: To find the "dependency" that you need to add to the
 // `libraryDependencies` set, which in the above example looks like this:
 
-// "org.typelevel" %% "cats-core" % "2.0.0"
+// "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
 
 // You can use Scaladex, an index of all known published Scala libraries. There,
 // after you find the library you want, you can just copy/paste the dependency
 // information that you need into your build file. For example, on the
-// typelevel/cats Scaladex page,
-// https://index.scala-lang.org/typelevel/cats, you can copy/paste the sbt
-// dependency from the sbt box on the right-hand side of the screen.
+// scala/scala-parser-combinators Scaladex page,
+// https://index.scala-lang.org/scala/scala-parser-combinators, you can copy/paste
+// the sbt dependency from the sbt box on the right-hand side of the screen.
 
 // IMPORTANT NOTE: while build files look _kind of_ like regular Scala, it's
 // important to note that syntax in *.sbt files doesn't always behave like

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -24,7 +24,9 @@ version := "1.0"
 
 // Want to use a published library in your project?
 // You can define other libraries as dependencies in your build like this:
-libraryDependencies += "org.typelevel" %% "cats-core" % "1.4.0"
+
+// libraryDependencies += "org.typelevel" %% "cats-core" % "1.4.0"
+
 // Here, `libraryDependencies` is a set of dependencies, and by using `+=`,
 // we're adding the cats dependency to the set of dependencies that sbt will go
 // and fetch when it starts up.


### PR DESCRIPTION
This template is used in [Getting started with scala and sbt at scala-lang.org](https://docs.scala-lang.org/getting-started-sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.html#create-the-project).
Cats is unnecessary for beginner.