### PR TITLE
test on OpenJDK 8 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ cache:
     - $HOME/.sbt/boot/
 
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 
 script:
   ## This runs the template with the default parameters, and runs test within the templated app.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18


### PR DESCRIPTION
`oraclejdk8` doesn't work anymore on Travis-CI, so PR validation
wasn't working

and then adding 11 is just a good thing in general