### PR TITLE
bump Scala and sbt versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ A [Giter8][g8] template for a Hello World application, used in the [Getting Star
 
 Template license
 ----------------
-Written in 2017-2018 by the Scala Center
+Written in 2017-2019 by the Scala Center
 
 To the extent possible under law, the author(s) have dedicated all copyright and related
 and neighboring rights to this template to the public domain worldwide.

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,7 +1,7 @@
 
 // The simplest possible sbt build file is just one line:
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.1"
 // That is, to create a valid sbt build, all you've got to do is define the
 // version of Scala you'd like your project to use.
 
@@ -9,7 +9,7 @@ scalaVersion := "2.12.8"
 
 // Lines like the above defining `scalaVersion` are called "settings" Settings
 // are key/value pairs. In the case of `scalaVersion`, the key is "scalaVersion"
-// and the value is "2.12.8"
+// and the value is "2.13.1"
 
 // It's possible to define many kinds of settings, such as:
 
@@ -24,7 +24,7 @@ version := "1.0"
 
 // Want to use a published library in your project?
 // You can define other libraries as dependencies in your build like this:
-libraryDependencies += "org.typelevel" %% "cats-core" % "1.6.0"
+libraryDependencies += "org.typelevel" %% "cats-core" % "2.0.0"
 // Here, `libraryDependencies` is a set of dependencies, and by using `+=`,
 // we're adding the cats dependency to the set of dependencies that sbt will go
 // and fetch when it starts up.
@@ -34,7 +34,7 @@ libraryDependencies += "org.typelevel" %% "cats-core" % "1.6.0"
 // TIP: To find the "dependency" that you need to add to the
 // `libraryDependencies` set, which in the above example looks like this:
 
-// "org.typelevel" %% "cats-core" % "1.6.0"
+// "org.typelevel" %% "cats-core" % "2.0.0"
 
 // You can use Scaladex, an index of all known published Scala libraries. There,
 // after you find the library you want, you can just copy/paste the dependency
@@ -66,7 +66,7 @@ libraryDependencies += "org.typelevel" %% "cats-core" % "1.6.0"
 //   settings(
 //     inThisBuild(List(
 //       organization := "ch.epfl.scala",
-//       scalaVersion := "2.12.8"
+//       scalaVersion := "2.13.1"
 //     )),
 //     name := "hello-world"
 //   )

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2


### PR DESCRIPTION
the sbt version bump is crucial because 1.2.8 doesn't work
on JDK 13