### PR TITLE
Update sbt and Scala versions

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.4.2

--- a/project/giter8.sbt
+++ b/project/giter8.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.11.0")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.12.0")

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,7 +1,7 @@
 
 // The simplest possible sbt build file is just one line:
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.3"
 // That is, to create a valid sbt build, all you've got to do is define the
 // version of Scala you'd like your project to use.
 
@@ -9,7 +9,7 @@ scalaVersion := "2.13.1"
 
 // Lines like the above defining `scalaVersion` are called "settings". Settings
 // are key/value pairs. In the case of `scalaVersion`, the key is "scalaVersion"
-// and the value is "2.13.1"
+// and the value is "2.13.3"
 
 // It's possible to define many kinds of settings, such as:
 
@@ -68,7 +68,7 @@ libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % 
 //   settings(
 //     inThisBuild(List(
 //       organization := "ch.epfl.scala",
-//       scalaVersion := "2.13.1"
+//       scalaVersion := "2.13.3"
 //     )),
 //     name := "hello-world"
 //   )

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.4.2


### PR DESCRIPTION
I had a colleague following the [Getting Started](https://docs.scala-lang.org/getting-started/) section of the website which instructs to use this template. They had a question which made me look at it and realize that some of the versions were out of date, sbt, scala, and giter8 template. This pr just updates those.