### PR TITLE
Upgrade Scala minor version

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,7 +1,7 @@
 
 // The simplest possible sbt build file is just one line:
 
-scalaVersion := "2.13.3"
+scalaVersion := "2.13.8"
 // That is, to create a valid sbt build, all you've got to do is define the
 // version of Scala you'd like your project to use.
 
@@ -9,7 +9,7 @@ scalaVersion := "2.13.3"
 
 // Lines like the above defining `scalaVersion` are called "settings". Settings
 // are key/value pairs. In the case of `scalaVersion`, the key is "scalaVersion"
-// and the value is "2.13.3"
+// and the value is "2.13.8"
 
 // It's possible to define many kinds of settings, such as:
 
@@ -68,7 +68,7 @@ libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % 
 //   settings(
 //     inThisBuild(List(
 //       organization := "ch.epfl.scala",
-//       scalaVersion := "2.13.3"
+//       scalaVersion := "2.13.8"
 //     )),
 //     name := "hello-world"
 //   )


### PR DESCRIPTION
Using this starter in Metals gives the warning
> You are using legacy Scala version 2.13.3, which might not be supported in future versions of Metals. Please upgrade to Scala version 2.13.8.